### PR TITLE
Pass element.props when initializing a component using React.createElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "chai": "^4.2.0",
     "mocha": "^6.2.2",
     "mocha-clean": "^1.0.0",
+    "prop-types": "^15.7.2",
     "react": "^16.11.0",
-    "react-test-renderer": "^16.11.0"
+    "react-test-renderer": "^16.11.0",
+    "sinon": "^9.0.0"
   },
   "babel": {
     "presets": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 function elementHasType(Component) {
-	return (element) => element.type === React.createElement(Component).type
+	return (element) => element.type === React.createElement(Component, element.props).type
 }
 
 export function oneByType(children, Component) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import React from 'react'
 
 function elementHasType(Component) {
-	return (element) => element.type === React.createElement(Component, element.props).type
+	const type = getType(Component)
+	return (element) => element.type === type
 }
 
 export function oneByType(children, Component) {
@@ -13,9 +14,17 @@ export function allByType(children, Component) {
 }
 
 export function withoutTypes(children, ...Components) {
-	const types = Components.map((C) => React.createElement(C).type)
+	const types = Components.map(getType)
 
 	return React.Children.toArray(children).filter(
 		(child) => !types.includes(child.type)
 	)
+}
+
+function getType(Component) {
+	const original = console.error
+	console.error = () => {}
+	const element = React.createElement(Component)
+	console.error = original
+	return element.type
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,11 +1,25 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import {expect} from 'chai'
+import {spy} from 'sinon'
 import {create} from 'react-test-renderer'
 import {oneByType, allByType, withoutTypes} from '../src/index'
 
 const Type1 = ({v}) => <p>{v}</p>
+Type1.propTypes = {
+	v: PropTypes.string.isRequired
+}
 const Type2 = ({v}) => <p>{v}</p>
 const Type3 = ({v}) => <p>{v}</p>
+
+beforeEach(() => {
+	spy(console, `error`)
+})
+
+afterEach(() => {
+	expect(console.error.called).to.be.false
+	console.error.restore()
+})
 
 describe(`#oneByType`, () => {
 	it(`returns a child of the given type`, () => {
@@ -44,14 +58,14 @@ describe(`#allByType`, () => {
 
 describe(`#withoutTypes`, () => {
 	it(`returns all children not of the given types`, () => {
-		const child1 = <Type1 />
+		const child1 = <Type1 v="1" />
 		const child2 = <div />
 		const renderer = create(<div>{child1}<Type2 /><Type3 />{child2}</div>)
 		expect(withoutTypes(renderer.root.props.children, Type2, Type3).map(withoutKey)).to.deep.equal([child1, child2].map(withoutKey))
 	})
 
 	it(`returns an empty array if no children not of the given type exist`, () => {
-		const renderer = create(<div><Type1 /><Type2 /></div>)
+		const renderer = create(<div><Type1 v="1" /><Type2 /></div>)
 		expect(withoutTypes(renderer.root.props.children, Type1, Type2)).to.be.empty
 	})
 })


### PR DESCRIPTION
This change prevents warnings for components with required props.